### PR TITLE
Remove prefix from key in config.list_entries

### DIFF
--- a/rstblog/config.py
+++ b/rstblog/config.py
@@ -39,7 +39,7 @@ class Config(object):
         for layer in self.stack:
             for key, value in layer.iteritems():
                 if key.startswith(prefix):
-                    rv[key] = value
+                    rv[key[len(prefix):]] = value
         return rv
 
     def merged_get(self, key):


### PR DESCRIPTION
The `config.list_entries` method (https://github.com/oddbird/rstblog/blob/oddbird/rstblog/config.py#L36) is only used currently to fetch an object matching filename patterns to programs (https://github.com/oddbird/rstblog/blob/oddbird/rstblog/builder.py#L284). It should return e.g.:

```python
{
    '*.rst': 'rst'
}
```

Without this PR, currently if you define a custom programs object in `config.yml`, e.g.:

```yaml
programs:
  '*.rst': 'rst'
  '*.jpg': 'image'
```

It returns:

```py
{
    'programs.*.rst': 'rst',
    'programs.*.jpg': 'image'
}
```

This PR fixes it to instead return the expected:

```py
{
    '*.rst': 'rst',
    '*.jpg': 'image'
}
```